### PR TITLE
Fix part of 8423 and Unblock #11776: Check to enforce use of Args, Returns and Raises in the docstring

### DIFF
--- a/scripts/linters/pylint_extensions.py
+++ b/scripts/linters/pylint_extensions.py
@@ -44,6 +44,8 @@ ALLOWED_TERMINATING_PUNCTUATIONS = ['.', '?', '}', ']', ')']
 EXCLUDED_PHRASES = [
     'coding:', 'pylint:', 'http://', 'https://', 'scripts/', 'extract_node']
 
+NO_REQUIRED_DOC_RGX = re.compile("^_")
+
 import astroid  # isort:skip  pylint: disable=wrong-import-order, wrong-import-position
 from pylint import checkers  # isort:skip  pylint: disable=wrong-import-order, wrong-import-position
 from pylint import interfaces  # isort:skip  pylint: disable=wrong-import-order, wrong-import-position
@@ -549,21 +551,21 @@ class DocstringParameterChecker(checkers.BaseChecker):
     options = (
         (
             'accept-no-param-doc',
-            {'default': True, 'type': 'yn', 'metavar': '<y or n>',
+            {'default': False, 'type': 'yn', 'metavar': '<y or n>',
              'help': 'Whether to accept totally missing parameter '
                      'documentation in the docstring of a '
                      'function that has parameters.'
             }),
         (
             'accept-no-raise-doc',
-            {'default': True, 'type': 'yn', 'metavar': '<y or n>',
+            {'default': False, 'type': 'yn', 'metavar': '<y or n>',
              'help': 'Whether to accept totally missing raises '
                      'documentation in the docstring of a function that '
                      'raises an exception.'
             }),
         (
             'accept-no-return-doc',
-            {'default': True, 'type': 'yn', 'metavar': '<y or n>',
+            {'default': False, 'type': 'yn', 'metavar': '<y or n>',
              'help': 'Whether to accept totally missing return '
                      'documentation in the docstring of a function that '
                      'returns a statement.'
@@ -573,6 +575,16 @@ class DocstringParameterChecker(checkers.BaseChecker):
             {'default': True, 'type': 'yn', 'metavar': '<y or n>',
              'help': 'Whether to accept totally missing yields '
                      'documentation in the docstring of a generator.'
+            }),
+        (
+            "no-docstring-rgx",
+            {
+                "default": NO_REQUIRED_DOC_RGX,
+                "type": "regexp",
+                "metavar": "<regexp>",
+                "help": "Regular expression which should only match "
+                "function or class names that do not require a "
+                "docstring.",
             }),
         )
 
@@ -627,6 +639,8 @@ class DocstringParameterChecker(checkers.BaseChecker):
             node: astroid.scoped_nodes.Function. Node for a function or
                 method definition in the AST.
         """
+        if self.config.no_docstring_rgx.match(node.name) is not None:
+            return
         node_doc = docstrings_checker.docstringify(node.doc)
         self.check_functiondef_params(node, node_doc)
         self.check_functiondef_returns(node, node_doc)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #8423 and unblocks #11776 for further work.
2. This PR does the following: 

Find out the solution for solving the task `Check to enforce use of Args, Returns and Raises in the docstring`. Since it has been found in past that this will have a lot of files to be fixed, we want to refine this approach to exclude test files, and also make #11776 ready to fix the files separately first.

- **To enfoce use of Args, Returns and Raises in the docsrting** - we can just set the pylint options `'accept-no-param-doc'`, `'accept-no-raise-doc'`, `'accept-no-return-doc'` to **False**. This will make sure if Args, Returns, Raises are present, then their corresponding entries are also present.
  - Proof that this works: After making the above change I ran the command `python -m scripts.linters.pre_commit_linter --path=core/domain/user_services_test.py`, and the following output came:
    <img width="524" alt="Screenshot 2021-04-14 at 11 04 27 PM" src="https://user-images.githubusercontent.com/32328861/114754051-c5c9c000-9d75-11eb-8dc5-5a6967436301.png">
    And I verified that these were valid cases.
- **To exclude the docstring lint check for test related files**, we already have a option defined in `.pylintrc` named [no-docstring-rgx](https://github.com/oppia/oppia/blob/7964a49d527164a567c51021b9757bca60b7e683/.pylintrc#L48) = `test_[a-z_]*|[A-Za-z]*Tests|Mock[A-Za-z]*|mock_[a-z_]*|setUp|tearDown|__.*__`. But when I try to use this option using the code shown below, I get the following error - **OptionConflictError: option --no-docstring-rgx: conflicting option string(s): --no-docstring-rgx**:
```bash
Traceback (most recent call last):
  File "scripts/concurrent_task_utils.py", line 101, in run
    self.task_results = self.func()
  File "scripts/linters/python_linter.py", line 410, in perform_all_lint_checks
    linter_stdout.append(self.lint_py_files())
  File "scripts/linters/python_linter.py", line 275, in lint_py_files
    exit=False).linter
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 1318, in __init__
    linter.load_plugin_modules(plugins)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 501, in load_plugin_modules
    module.register(self)
  File "scripts/linters/pylint_extensions.py", line 2164, in register
    linter.register_checker(DocstringParameterChecker(linter))
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 589, in register_checker
    self.register_options_provider(checker)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/config.py", line 498, in register_options_provider
    non_group_spec_options, provider)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/config.py", line 524, in add_option_group
    self.add_optik_option(provider, group, opt, optdict)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/config.py", line 528, in add_optik_option
    option = optikcontainer.add_option(*args, **optdict)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/optparse.py", line 1021, in add_option
    self._check_conflict(option)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/optparse.py", line 996, in _check_conflict
    option)
OptionConflictError: option --no-docstring-rgx: conflicting option string(s): --no-docstring-rgx
```
Although this is the same method described in [pylint documentation](https://github.com/PyCQA/pylint/blob/af52033971eccecea47597ebbfaeac15773b3e1b/pylint/checkers/base.py#L2143), but didn't work.

**Method 2 that I tried**: Set the value of `no-docstring-rgx` in .pylintrc to be the same as `^_` (i.e what I defined as default value for `NO_REQUIRED_DOC_RGX ` in pylint_extensions file, but I still got the same error.

**Method 3 that I tried**: If I try to avoid re-defining the option in `DocstringParameterChecker` class, and just use it directly in the same way, then I get the following error - **AttributeError: Values instance has no attribute 'no_docstring_rgx'**:
```bash
Traceback (most recent call last):
  File "scripts/concurrent_task_utils.py", line 101, in run
    self.task_results = self.func()
  File "scripts/linters/python_linter.py", line 410, in perform_all_lint_checks
    linter_stdout.append(self.lint_py_files())
  File "scripts/linters/python_linter.py", line 275, in lint_py_files
    exit=False).linter
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 1353, in __init__
    linter.check(args)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 774, in check
    self._do_check(files_or_modules)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 907, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/lint.py", line 986, in check_astroid_module
    walker.walk(ast_node)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/utils.py", line 1014, in walk
    self.walk(child)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/utils.py", line 1014, in walk
    self.walk(child)
  File "/Users/sajalasati/opensource/oppia/../oppia_tools/pylint-quotes-0.1.8/pylint/utils.py", line 1011, in walk
    cb(astroid)
  File "scripts/linters/pylint_extensions.py", line 632, in visit_functiondef
    if self.config.no_docstring_rgx.match(node.name) is not None:
AttributeError: Values instance has no attribute 'no_docstring_rgx'
```

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
